### PR TITLE
Remote backend should use relative URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* April 26, 2017 - 0.1.2
+Allow clients to use path prefixes.
+
 * April 11, 2017 - 0.1.1
 Adding Tom Copeland to authors
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Configure the gem using your issued Alloy credentials in an initializer file. Fo
 Alloy::KYC.configure do |config|
   config.application_token = ENV['ALLOY_APPLICATION_TOKEN']
   config.application_secret = ENV['ALLOY_APPLICATION_SECRET']
+  config.api_endpoint = "https://alloy.co/v1/"
 end
 ```
 

--- a/lib/alloy/kyc/backends/remote.rb
+++ b/lib/alloy/kyc/backends/remote.rb
@@ -11,7 +11,7 @@ module Alloy
 
         def get_bearer_token
           conn.basic_auth(Alloy::KYC.configuration.application_token, Alloy::KYC.configuration.application_secret)
-          response = conn.post("/oauth/bearer")
+          response = conn.post("oauth/bearer")
           token_info = JSON.parse(response.body)
           @bearer_token = BearerToken.new(token_info["access_token"], token_info["expires_in"])
         end
@@ -28,7 +28,7 @@ module Alloy
 
         # domain methods
         def create_evaluation(params)
-          post("/evaluations", params)
+          post("evaluations", params)
         end
 
         def submit_oow_responses(path, responses)

--- a/lib/alloy/kyc/configuration.rb
+++ b/lib/alloy/kyc/configuration.rb
@@ -9,7 +9,7 @@ module Alloy
       def initialize
         @application_token = "dpDD6z4olOSI7N4fMCsAlKjFa7reBYhu"
         @application_secret = "oJm3niQX1Pdy4z675kefEIKBgFn9tQ45"
-        @api_endpoint = "https://sandbox.alloy.co/v1"
+        @api_endpoint = "https://sandbox.alloy.co/v1/"
         @backend = Alloy::KYC::Backends::Remote.new
       end
     end

--- a/lib/alloy/kyc/evaluation.rb
+++ b/lib/alloy/kyc/evaluation.rb
@@ -33,12 +33,12 @@ module Alloy
       # name_first: "Charles",
       # name_last: "Hearn"}
       def submit_oow_responses(responses)
-        response = Alloy::KYC.configuration.backend.submit_oow_responses("/evaluations/#{self.evaluation_token}", responses)
+        response = Alloy::KYC.configuration.backend.submit_oow_responses("evaluations/#{self.evaluation_token}", responses)
         self.class.new(JSON.parse(response.body))
       end
 
       def fork
-        response = Alloy::KYC.configuration.backend.fork_evaluation("/evaluations/#{self.evaluation_token}")
+        response = Alloy::KYC.configuration.backend.fork_evaluation("evaluations/#{self.evaluation_token}")
         self.class.new(JSON.parse(response.body))
       end
 

--- a/lib/alloy/kyc/version.rb
+++ b/lib/alloy/kyc/version.rb
@@ -1,5 +1,5 @@
 module Alloy
   module KYC
-    VERSION = "0.1.1"
+    VERSION = "0.1.2"
   end
 end

--- a/spec/fixtures/evaluation.yml
+++ b/spec/fixtures/evaluation.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://sandbox.alloy.co/evaluations
+    uri: https://sandbox.alloy.co/v1/evaluations
     body:
       encoding: UTF-8
       string: address_city=Richmond&address_country_code=US&address_line_1=1717+E+Test+St&address_postal_code=23220&address_state=VA&birth_date=1985-01-23&document_ssn=123456789&email_address=tommy%40alloy.co&name_first=Thomas&name_last=Nicholas&phone_number=18042562188&social_twitter=tommyrva

--- a/spec/fixtures/fork_evaluation.yml
+++ b/spec/fixtures/fork_evaluation.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://sandbox.alloy.co/evaluations/S-ds1uAPbr4AK6x9ojkcda
+    uri: https://sandbox.alloy.co/v1/evaluations/S-ds1uAPbr4AK6x9ojkcda
     body:
       encoding: UTF-8
       string: ''

--- a/spec/fixtures/get_bearer_token.yml
+++ b/spec/fixtures/get_bearer_token.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://sandbox.alloy.co/oauth/bearer
+    uri: https://sandbox.alloy.co/v1/oauth/bearer
     body:
       encoding: UTF-8
       string: ''

--- a/spec/fixtures/oow_evaluation.yml
+++ b/spec/fixtures/oow_evaluation.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://sandbox.alloy.co/evaluations
+    uri: https://sandbox.alloy.co/v1/evaluations
     body:
       encoding: UTF-8
       string: address_city=Washington&address_country_code=US&address_line_1=1717+E+Test+St&address_postal_code=20005&address_state=DC&birth_date=1985-01-01&document_ssn=123456789&name_first=John&name_last=Doe&phone_number=8005551212

--- a/spec/fixtures/submit_oow_responses.yml
+++ b/spec/fixtures/submit_oow_responses.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: patch
-    uri: https://sandbox.alloy.co/evaluations/S-ds1uAPbr4AK6x9ojkcda
+    uri: https://sandbox.alloy.co/v1/evaluations/S-ds1uAPbr4AK6x9ojkcda
     body:
       encoding: UTF-8
       string: answers%5B%5D%5Banswer_id%5D=1&answers%5B%5D%5Bquestion_id%5D=1&answers%5B%5D%5Banswer_id%5D=5&answers%5B%5D%5Bquestion_id%5D=2&answers%5B%5D%5Banswer_id%5D=2&answers%5B%5D%5Bquestion_id%5D=3&answers%5B%5D%5Banswer_id%5D=1&answers%5B%5D%5Bquestion_id%5D=4&answers%5B%5D%5Banswer_id%5D=5&answers%5B%5D%5Bquestion_id%5D=5&name_first=Charles&name_last=Hearn


### PR DESCRIPTION
Otherwise client apps cannot use request prefixes.  That is, given
http://foo/bar and post("/buz"), Faraday will post
to http://foo/buz.  So removing the leading slash gives clients
more flexibility.